### PR TITLE
Update YouTube badge in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@
   <a href="https://docs.powersync.com/"><img src="https://img.shields.io/badge/status%20-%20stable%20-%20%23aa00ff"/></a>
   <a href="https://github.com/powersync-ja"><img src="https://img.shields.io/github/stars/powersync-ja?style=social"/></a>
   <a href="https://discord.gg/powersync" target="_blank"><img src="https://img.shields.io/discord/1138230179878154300?style=social&logo=discord&logoColor=%235865f2&label=Join%20Discord%20server"/></a>
-  <a href="https://www.youtube.com/@powersync_" target="_blank"><img src="https://img.shields.io/youtube/channel/subscribers/UCSDdZvrZuizmc2EMBuTs2Qg?style=social&label=YouTube%20%40powersync_"/></a>
+ <a href="https://www.youtube.com/@powersync_" target="_blank"><img src="https://img.shields.io/badge/YouTube-%40powersync__-red?style=social&logo=youtube"/></a>
   <a href="https://twitter.com/powersync_" target="_blank"><img src="https://img.shields.io/twitter/follow/powersync_?&label=%40powersync_&style=social"/></a>
 </p>
 


### PR DESCRIPTION
I asked Claude to investigate why our YouTube badge is showing "invalid" and it found this: https://github.com/badges/shields/issues/12102

This replaces it with a static badge (no subscriber count shown)